### PR TITLE
Fixes bug in rendering URL connection string

### DIFF
--- a/auto_rest/models.py
+++ b/auto_rest/models.py
@@ -34,16 +34,14 @@ def create_db_url(
         The fully qualified database connection URL.
     """
 
-    return str(
-        URL.create(
-            drivername=driver,
-            username=username,
-            password=password,
-            host=host,
-            port=port,
-            database=database
-        )
-    )
+    return URL.create(
+        drivername=driver,
+        username=username,
+        password=password,
+        host=host,
+        port=port,
+        database=database
+    ).render_as_string(hide_password=False)
 
 
 def create_connection_pool(url: str, pool_size: int, max_overflow: int, pool_timeout: int) -> Engine:

--- a/tests/models/test_create_db_url.py
+++ b/tests/models/test_create_db_url.py
@@ -1,0 +1,97 @@
+import unittest
+
+from auto_rest.models import create_db_url
+
+
+class TestCreateDbUrl(unittest.TestCase):
+    """Unit tests for the `create_db_url` function."""
+
+    def test_create_db_url_with_all_params(self) -> None:
+        """Test creating a DB URL with all parameters provided."""
+
+        result = create_db_url(
+            driver="postgresql",
+            host="localhost",
+            port=5432,
+            database="test_db",
+            username="user",
+            password="password"
+        )
+
+        expected_url = "postgresql://user:password@localhost:5432/test_db"
+        self.assertEqual(expected_url, result)
+
+    def test_create_db_url_without_password(self) -> None:
+        """Test creating a DB URL without password."""
+
+        result = create_db_url(
+            driver="postgresql",
+            host="localhost",
+            port=5432,
+            database="test_db",
+            username="user",
+            password=None
+        )
+
+        expected_url = "postgresql://user@localhost:5432/test_db"
+        self.assertEqual(expected_url, result)
+
+    def test_create_db_url_without_username_and_password(self) -> None:
+        """Test creating a DB URL without username and password."""
+
+        result = create_db_url(
+            driver="postgresql",
+            host="localhost",
+            port=5432,
+            database="test_db",
+            username=None,
+            password=None
+        )
+
+        expected_url = "postgresql://localhost:5432/test_db"
+        self.assertEqual(expected_url, result)
+
+    def test_create_db_url_without_host(self) -> None:
+        """Test creating a DB URL without host."""
+
+        result = create_db_url(
+            driver="postgresql",
+            host=None,
+            port=5432,
+            database="test_db",
+            username="user",
+            password="password"
+        )
+
+        expected_url = "postgresql://user:password@:5432/test_db"
+        self.assertEqual(expected_url, result)
+
+    def test_create_db_url_without_port(self) -> None:
+        """Test creating a DB URL without port."""
+
+        result = create_db_url(
+            driver="postgresql",
+            host="localhost",
+            port=None,
+            database="test_db",
+            username="user",
+            password="password"
+        )
+
+        expected_url = "postgresql://user:password@localhost/test_db"
+        self.assertEqual(expected_url, result)
+
+    def test_create_db_url_without_database(self) -> None:
+        """Test creating a DB URL without database."""
+
+        result = create_db_url(
+            driver="postgresql",
+            host="localhost",
+            port=5432,
+            database=None,
+            username="user",
+            password="password"
+        )
+
+        expected_url = "postgresql://user:password@localhost:5432"
+        self.assertEqual(expected_url, result)


### PR DESCRIPTION
The password in the db connection string was being obfuscated. A useful security feature,just one being applied too early.