### PR TITLE
Fixes bug in parsing sqlite file paths

### DIFF
--- a/auto_rest/models.py
+++ b/auto_rest/models.py
@@ -1,6 +1,7 @@
 """ORM layer used to dynamically map database schemas and generate model interfaces."""
 
 import logging
+from pathlib import Path
 
 from sqlalchemy import create_engine, Engine, MetaData, URL
 from sqlalchemy.orm import declarative_base
@@ -14,11 +15,11 @@ ModelBase = declarative_base()
 
 def create_db_url(
     driver: str,
-    host: str | None,
-    port: int | None,
-    database: str | None,
-    username: str | None,
-    password: str | None
+    host: str,
+    port: int | None = None,
+    database: str | None = None,
+    username: str | None = None,
+    password: str | None = None
 ) -> str:
     """Create a database URL from the provided parameters.
 
@@ -33,6 +34,15 @@ def create_db_url(
     Returns:
         The fully qualified database connection URL.
     """
+
+    # Handle special case where SQLite uses file paths
+    if driver == "sqlite" and host:
+        path = Path(host)
+        if path.is_absolute():
+            return f"sqlite:///{path}"
+
+        else:
+            return f"sqlite:///{path}"
 
     return URL.create(
         drivername=driver,

--- a/tests/models/test_create_db_url.py
+++ b/tests/models/test_create_db_url.py
@@ -95,3 +95,31 @@ class TestCreateDbUrl(unittest.TestCase):
 
         expected_url = "postgresql://user:password@localhost:5432"
         self.assertEqual(expected_url, result)
+
+    def test_create_db_url_sqlite_relative_path(self):
+        """Test SQLite URL with a relative file path."""
+
+        result = create_db_url(
+            driver="sqlite",
+            host="path/to/database.db",  # Relative path
+            port=None,
+            database=None,
+            username=None,
+            password=None
+        )
+        expected_url = "sqlite:///path/to/database.db"
+        self.assertEqual(result, expected_url)
+
+    def test_create_db_url_sqlite_absolute_path(self):
+        """Test SQLite URL with an absolute file path."""
+
+        result = create_db_url(
+            driver="sqlite",
+            host="/absolute/path/to/database.db",  # Absolute path
+            port=None,
+            database=None,
+            username=None,
+            password=None
+        )
+        expected_url = "sqlite:////absolute/path/to/database.db"
+        self.assertEqual(result, expected_url)

--- a/tests/models/test_create_db_url.py
+++ b/tests/models/test_create_db_url.py
@@ -96,7 +96,7 @@ class TestCreateDbUrl(unittest.TestCase):
         expected_url = "postgresql://user:password@localhost:5432"
         self.assertEqual(expected_url, result)
 
-    def test_create_db_url_sqlite_relative_path(self):
+    def test_create_db_url_sqlite_relative_path(self) -> None:
         """Test SQLite URL with a relative file path."""
 
         result = create_db_url(
@@ -110,7 +110,7 @@ class TestCreateDbUrl(unittest.TestCase):
         expected_url = "sqlite:///path/to/database.db"
         self.assertEqual(result, expected_url)
 
-    def test_create_db_url_sqlite_absolute_path(self):
+    def test_create_db_url_sqlite_absolute_path(self) -> None:
         """Test SQLite URL with an absolute file path."""
 
         result = create_db_url(


### PR DESCRIPTION
SQLite databases require a bit of special handling when formatting their connection - specifically when it comes to differences in formatting relative/absolute file paths.