### PR TITLE
Makes docs endpoint optional

### DIFF
--- a/auto_rest/__main__.py
+++ b/auto_rest/__main__.py
@@ -40,7 +40,8 @@ def run_application(
     server_host: str,
     server_port: int,
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-    enable_meta: bool
+    enable_docs: bool,
+    enable_meta: bool,
 ) -> None:
     """Map a database schema and launch an API server.
 
@@ -60,6 +61,7 @@ def run_application(
         server_host: The API server host address.
         server_port: The API server port number.
         log_level: The desired logging level ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL').
+        enable_docs: Whether to enable the 'docs' API endpoint.
         enable_meta: Whether to enable the 'meta' API endpoint.
     """
 
@@ -72,7 +74,7 @@ def run_application(
 
     # Build the app
     db_models = create_db_models(db_conn)
-    app = create_app(db_conn, db_models, enable_meta=enable_meta)
+    app = create_app(db_conn, db_models, enable_meta=enable_meta, enable_docs=enable_docs)
 
     # Launch a uvicorn server
     run_app(app, server_host, server_port, log_level=log_level)

--- a/auto_rest/app.py
+++ b/auto_rest/app.py
@@ -40,7 +40,7 @@ def configure_logging(level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITI
     )
 
 
-def create_app(conn: Engine, models: dict[str, ModelBase], enable_meta: bool = False) -> FastAPI:
+def create_app(conn: Engine, models: dict[str, ModelBase], enable_meta: bool = False, enable_docs: bool = False) -> FastAPI:
     """Initialize a new FastAPI Application.
 
     Args:
@@ -56,7 +56,7 @@ def create_app(conn: Engine, models: dict[str, ModelBase], enable_meta: bool = F
         title=NAME.title(),
         version=VERSION,
         summary=f"A REST API generated dynamically from the '{conn.url.database}' database schema.",
-        docs_url="/docs/",
+        docs_url="/docs/" if enable_docs else None,
         redoc_url=None
     )
 

--- a/auto_rest/cli.py
+++ b/auto_rest/cli.py
@@ -33,6 +33,7 @@ def create_argument_parser(exit_on_error: bool = True) -> ArgumentParser:
     )
 
     features = parser.add_argument_group(title="API features")
+    features.add_argument("--enable-docs", action="store_true", help="enable the 'docs' endpoint.")
     features.add_argument("--enable-meta", action="store_true", help="enable the 'meta' endpoint.")
 
     driver = parser.add_argument_group("database type")

--- a/auto_rest/handlers.py
+++ b/auto_rest/handlers.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 async def welcome_handler() -> dict:
     """Return a welcome message in JSON format pointing users to the docs."""
 
-    return {"message": "Welcome to AutoRest! See the /docs/ endpoint to get started."}
+    return {"message": "Welcome to Auto-Rest!"}
 
 
 async def version_handler() -> dict:

--- a/tests/app/test_create_app.py
+++ b/tests/app/test_create_app.py
@@ -56,6 +56,22 @@ class TestCreateApp(unittest.TestCase):
         response = self.client.get("/version")
         self.assertEqual(200, response.status_code)
 
+    def test_docs_endpoint_disabled(self) -> None:
+        """Test the application has no docs endpoint by default."""
+
+        default_app = create_app(self.engine, self.mock_models)
+        default_client = TestClient(default_app)
+        response = default_client.get("/docs")
+        self.assertEqual(404, response.status_code)
+
+    def test_docs_endpoint_enabled(self) -> None:
+        """Test the application has a docs endpoint when enabled."""
+
+        default_app = create_app(self.engine, self.mock_models, enable_docs=True)
+        default_client = TestClient(default_app)
+        response = default_client.get("/docs")
+        self.assertEqual(200, response.status_code)
+
     def test_meta_endpoint_disabled(self) -> None:
         """Test the application has no meta endpoint by default."""
 

--- a/tests/handlers/test_welcome_handler.py
+++ b/tests/handlers/test_welcome_handler.py
@@ -22,4 +22,4 @@ class TestWelcomeHandler(unittest.TestCase):
 
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual({"message": "Welcome to AutoRest! See the /docs/ endpoint to get started."}, response.json())
+        self.assertEqual({"message": "Welcome to AutoRest!"}, response.json())

--- a/tests/handlers/test_welcome_handler.py
+++ b/tests/handlers/test_welcome_handler.py
@@ -22,4 +22,4 @@ class TestWelcomeHandler(unittest.TestCase):
 
         response = self.client.get("/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual({"message": "Welcome to AutoRest!"}, response.json())
+        self.assertEqual({"message": "Welcome to Auto-Rest!"}, response.json())


### PR DESCRIPTION
Disables the docs endpoint by default and adds the `--enable-docs` flag to enable it.