### PR TITLE
Enforces consistent behavior when applying ordering/pagination params

### DIFF
--- a/auto_rest/app.py
+++ b/auto_rest/app.py
@@ -65,6 +65,7 @@ def create_app(engine: Engine, models: dict[str, ModelBase], enable_meta: bool =
     app.add_api_route("/version/", version_handler, methods=["GET"], tags=["Application Info"])
 
     if enable_meta:
+        logger.debug(f"Adding meta API route.")
         app.add_api_route(f"/meta/", create_meta_handler(engine), methods=["GET"], tags=["Application Info"])
 
     for model_name, model_class in models.items():

--- a/auto_rest/handlers.py
+++ b/auto_rest/handlers.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from starlette.responses import Response
 
-from .dependencies import apply_ordering_params, apply_pagination_params, get_ordering_params, get_pagination_params
+from .utils import apply_ordering_params, apply_pagination_params, get_ordering_params, get_pagination_params
 from .dist import version
 from .models import create_session_factory, ModelBase
 

--- a/tests/dependencies/test_apply_ordering_params.py
+++ b/tests/dependencies/test_apply_ordering_params.py
@@ -5,7 +5,7 @@ from fastapi import Response
 from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import asc, desc, Select
 
-from auto_rest.dependencies import apply_ordering_params
+from auto_rest.utils import apply_ordering_params
 
 
 class TestApplyOrderingParams(TestCase):
@@ -38,26 +38,36 @@ class TestApplyOrderingParams(TestCase):
         order_clause = result_query._order_by_clauses[0]
         self.assertEqual(str(order_clause), str(desc("column_name")))
 
-    def test_invalid_direction_param(self) -> None:
-        """Test an invalid direction defaults to ascending order."""
+    def test_missing_params(self) -> None:
+        """Test ordering is not applied when parameters are not provided."""
 
-        params = {"order_by": "column_name", "direction": "invalid"}
+        result_query = apply_ordering_params(self.query, {}, self.response)
+        self.assertFalse(result_query._order_by_clauses)
+
+    def test_missing_order_by_param(self):
+        """Test ordering is not applied when the order_by parameter is not provided."""
+
+        params = {"direction": "desc"}
         result_query = apply_ordering_params(self.query, params, self.response)
-        self.assertIsInstance(result_query, Select)
+        self.assertFalse(result_query._order_by_clauses)
+
+    def test_invalid_order_by_param(self):
+        """Test a ValueError is raised for an invalid order_by parameter."""
+
+        self.fail()  # This test requires implimenting additional testing structures.
+
+    def test_missing_direction_param(self) -> None:
+        """Test the direction parameter defaults to ascending."""
+
+        params = {"order_by": "column_name"}
+        result_query = apply_ordering_params(self.query, params, self.response)
 
         order_clause = result_query._order_by_clauses[0]
         self.assertEqual(str(order_clause), str(asc("column_name")))
 
-    def test_no_direction_param(self) -> None:
-        """Test that ascending order is applied by default when 'direction' is missing."""
+    def test_invalid_direction_param(self) -> None:
+        """Test a ValueError is raised for an invalid direction parameter."""
 
-        params = {"order_by": "column_name"}
-        with self.assertRaises(ValueError):
-            apply_ordering_params(self.query, params, self.response)
-
-    def test_no_order_by_param(self) -> None:
-        """Test that no ordering is applied when 'order_by' is missing."""
-
-        params = {"direction": "asc"}
+        params = {"order_by": "column_name", "direction": "invalid"}
         with self.assertRaises(ValueError):
             apply_ordering_params(self.query, params, self.response)

--- a/tests/dependencies/test_apply_ordering_params.py
+++ b/tests/dependencies/test_apply_ordering_params.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import skip, TestCase
 from unittest.mock import Mock
 
 from fastapi import Response
@@ -51,10 +51,11 @@ class TestApplyOrderingParams(TestCase):
         result_query = apply_ordering_params(self.query, params, self.response)
         self.assertFalse(result_query._order_by_clauses)
 
+    @skip("This test requires implementing additional testing structures.")
     def test_invalid_order_by_param(self):
         """Test a ValueError is raised for an invalid order_by parameter."""
 
-        self.fail()  # This test requires implimenting additional testing structures.
+        self.fail()
 
     def test_missing_direction_param(self) -> None:
         """Test the direction parameter defaults to ascending."""

--- a/tests/dependencies/test_get_ordering_params.py
+++ b/tests/dependencies/test_get_ordering_params.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
-from auto_rest.dependencies import get_ordering_params
+from auto_rest.utils import get_ordering_params
 
 
 class TestGetOrderingParams(TestCase):

--- a/tests/dependencies/test_get_pagination_params.py
+++ b/tests/dependencies/test_get_pagination_params.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
-from auto_rest.dependencies import get_pagination_params
+from auto_rest.utils import get_pagination_params
 
 
 class TestGetPaginationParams(TestCase):


### PR DESCRIPTION
Ensures both the `apply_pagination_params` and `apply_ordering_params` functions assume defaults where reasonable and raise errors when necessary.