### PR TITLE
Docstring and opinionated formatting pass.

### DIFF
--- a/auto_rest/app.py
+++ b/auto_rest/app.py
@@ -1,4 +1,4 @@
-"""Factory functions for building a FastAPI application."""
+"""Factory functions for building FastAPI application instances."""
 
 import logging
 from typing import Literal

--- a/auto_rest/cli.py
+++ b/auto_rest/cli.py
@@ -1,4 +1,4 @@
-"""Utilities for parsing and formatting command line arguments."""
+"""Defines the application command line interface and argument parser."""
 
 from argparse import ArgumentParser
 

--- a/auto_rest/models.py
+++ b/auto_rest/models.py
@@ -1,4 +1,4 @@
-"""Database layer used to dynamically map database schemas and generate model interfaces."""
+"""Database utilities used to map database schemas and generate model interfaces."""
 
 import asyncio
 import logging

--- a/tests/app/test_configure_logging.py
+++ b/tests/app/test_configure_logging.py
@@ -8,31 +8,31 @@ class TestConfigureLogging(TestCase):
     """Unit tests for the `configure_logging` function."""
 
     def test_log_level_debug(self) -> None:
-        """Test logging configuration for the DEBUG level."""
+        """Test logging configuration for the `DEBUG` level."""
 
         configure_logging("DEBUG")
         self.assertEqual(logging.DEBUG, logging.getLogger().level)
 
     def test_log_level_info(self) -> None:
-        """Test logging configuration for the INFO level."""
+        """Test logging configuration for the `INFO` level."""
 
         configure_logging("INFO")
         self.assertEqual(logging.INFO, logging.getLogger().level)
 
     def test_log_level_warning(self) -> None:
-        """Test logging configuration for the WARNING level."""
+        """Test logging configuration for the `WARNING` level."""
 
         configure_logging("WARNING")
         self.assertEqual(logging.WARNING, logging.getLogger().level)
 
     def test_log_level_error(self) -> None:
-        """Test logging configuration for the ERROR level."""
+        """Test logging configuration for the `ERROR` level."""
 
         configure_logging("ERROR")
         self.assertEqual(logging.ERROR, logging.getLogger().level)
 
     def test_log_level_critical(self) -> None:
-        """Test logging configuration for the CRITICAL level."""
+        """Test logging configuration for the `CRITICAL` level."""
 
         configure_logging("CRITICAL")
         self.assertEqual(logging.CRITICAL, logging.getLogger().level)

--- a/tests/app/test_create_app.py
+++ b/tests/app/test_create_app.py
@@ -57,7 +57,7 @@ class TestCreateApp(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_docs_endpoint_disabled(self) -> None:
-        """Test the application has no docs endpoint by default."""
+        """Test the application has no `/docs` endpoint by default."""
 
         default_app = create_app(self.engine, self.mock_models)
         default_client = TestClient(default_app)
@@ -65,7 +65,7 @@ class TestCreateApp(TestCase):
         self.assertEqual(404, response.status_code)
 
     def test_docs_endpoint_enabled(self) -> None:
-        """Test the application has a docs endpoint when enabled."""
+        """Test the application has a `/docs` endpoint when enabled."""
 
         default_app = create_app(self.engine, self.mock_models, enable_docs=True)
         default_client = TestClient(default_app)
@@ -73,7 +73,7 @@ class TestCreateApp(TestCase):
         self.assertEqual(200, response.status_code)
 
     def test_meta_endpoint_disabled(self) -> None:
-        """Test the application has no meta endpoint by default."""
+        """Test the application has no `/meta` endpoint by default."""
 
         default_app = create_app(self.engine, self.mock_models)
         default_client = TestClient(default_app)
@@ -81,7 +81,7 @@ class TestCreateApp(TestCase):
         self.assertEqual(404, response.status_code)
 
     def test_meta_endpoint_enabled(self) -> None:
-        """Test the application has a meta endpoint when enabled."""
+        """Test the application has a `/meta` endpoint when enabled."""
 
         default_app = create_app(self.engine, self.mock_models, enable_meta=True)
         default_client = TestClient(default_app)

--- a/tests/cli/test_create_argument_parser.py
+++ b/tests/cli/test_create_argument_parser.py
@@ -16,20 +16,20 @@ class TestCreateArgumentParser(TestCase):
         """Test the parser is created with the correct program name."""
 
         self.assertIsInstance(self.parser, ArgumentParser)
-        self.assertEqual(self.parser.prog, "auto-rest")
+        self.assertEqual("auto-rest", self.parser.prog)
 
     def test_log_level(self) -> None:
         """Test only valid log levels are accepted and default value is correct."""
 
         # Validate the default log level
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost"])
-        self.assertEqual(args.log_level, "INFO")
+        self.assertEqual("INFO", args.log_level)
 
         # Test valid logging levels
         valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR"]
         for level in valid_levels:
             args = self.parser.parse_args(["--sqlite", "--db-host", "localhost", "--log-level", level])
-            self.assertEqual(args.log_level, level)
+            self.assertEqual(level, args.log_level)
 
         # Test an invalid logging level
         with self.assertRaises(ArgumentError):
@@ -44,31 +44,31 @@ class TestCreateArgumentParser(TestCase):
 
         for flag, driver in zip(cli_flags, db_drivers):
             args = self.parser.parse_args([f"--{flag}", "--db-host", "localhost"])
-            self.assertEqual(args.db_driver, driver)
+            self.assertEqual(driver, args.db_driver)
 
         # Test custom driver
         args = self.parser.parse_args(["--driver", "custom-driver", "--db-host", "localhost"])
-        self.assertEqual(args.db_driver, "custom-driver")
+        self.assertEqual("custom-driver", args.db_driver)
 
     def test_db_settings(self) -> None:
-        """Test the database-related arguments and default values."""
+        """Test database-related arguments and default values."""
 
         # Test required database host
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost"])
-        self.assertEqual(args.db_host, "localhost")
+        self.assertEqual("localhost", args.db_host)
 
         # Test default database port
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost"])
-        self.assertEqual(args.db_port, None)
+        self.assertEqual(None, args.db_port)
 
         # Test optional db-name, user, and password
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost", "--db-name", "testdb", "--db-user", "user", "--db-pass", "password"])
-        self.assertEqual(args.db_name, "testdb")
-        self.assertEqual(args.db_user, "user")
-        self.assertEqual(args.db_pass, "password")
+        self.assertEqual("testdb", args.db_name)
+        self.assertEqual("user", args.db_user)
+        self.assertEqual("password", args.db_pass)
 
     def test_pool_settings(self) -> None:
-        """Test the database connection pool settings and defaults."""
+        """Test database connection pool settings and defaults."""
 
         # Test default pool settings (None should be default)
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost"])
@@ -78,9 +78,9 @@ class TestCreateArgumentParser(TestCase):
 
         # Test valid pool settings
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost", "--pool-min", "5", "--pool-max", "20", "--pool-out", "30"])
-        self.assertEqual(args.pool_min, 5)
-        self.assertEqual(args.pool_max, 20)
-        self.assertEqual(args.pool_out, 30)
+        self.assertEqual(5, args.pool_min)
+        self.assertEqual(20, args.pool_max)
+        self.assertEqual(30, args.pool_out)
 
     def test_enabled_docs_flag(self) -> None:
         """Test the `--enable-docs` flag behavior."""
@@ -105,14 +105,14 @@ class TestCreateArgumentParser(TestCase):
         self.assertTrue(args.enable_meta)
 
     def test_server_settings(self) -> None:
-        """Test server-related settings with default values."""
+        """Test server related settings and default values."""
 
         # Test default server host and port
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost"])
-        self.assertEqual(args.server_host, "127.0.0.1")
-        self.assertEqual(args.server_port, 8081)
+        self.assertEqual("127.0.0.1", args.server_host)
+        self.assertEqual(8081, args.server_port)
 
         # Test custom server host and port
         args = self.parser.parse_args(["--sqlite", "--db-host", "localhost", "--server-host", "0.0.0.0", "--server-port", "9090"])
-        self.assertEqual(args.server_host, "0.0.0.0")
-        self.assertEqual(args.server_port, 9090)
+        self.assertEqual("0.0.0.0", args.server_host)
+        self.assertEqual(9090, args.server_port)

--- a/tests/dependencies/test_apply_ordering_params.py
+++ b/tests/dependencies/test_apply_ordering_params.py
@@ -26,7 +26,7 @@ class TestApplyOrderingParams(TestCase):
         self.assertIsInstance(result_query, Select)
 
         order_clause = result_query._order_by_clauses[0]
-        self.assertEqual(str(order_clause), str(asc("column_name")))
+        self.assertEqual(str(asc("column_name")), str(order_clause))
 
     def test_valid_params_descending(self) -> None:
         """Test parameters are applied correctly for descending order."""
@@ -36,7 +36,7 @@ class TestApplyOrderingParams(TestCase):
         self.assertIsInstance(result_query, Select)
 
         order_clause = result_query._order_by_clauses[0]
-        self.assertEqual(str(order_clause), str(desc("column_name")))
+        self.assertEqual(str(desc("column_name")), str(order_clause))
 
     def test_missing_params(self) -> None:
         """Test ordering is not applied when parameters are not provided."""
@@ -45,7 +45,7 @@ class TestApplyOrderingParams(TestCase):
         self.assertFalse(result_query._order_by_clauses)
 
     def test_missing_order_by_param(self):
-        """Test ordering is not applied when the order_by parameter is not provided."""
+        """Test ordering is not applied when the `order_by` parameter is not provided."""
 
         params = {"direction": "desc"}
         result_query = apply_ordering_params(self.query, params, self.response)
@@ -53,21 +53,21 @@ class TestApplyOrderingParams(TestCase):
 
     @skip("This test requires implementing additional testing structures.")
     def test_invalid_order_by_param(self):
-        """Test a ValueError is raised for an invalid order_by parameter."""
+        """Test a ValueError is raised for an invalid `order_by` parameter."""
 
         self.fail()
 
     def test_missing_direction_param(self) -> None:
-        """Test the direction parameter defaults to ascending."""
+        """Test the `direction` parameter defaults to ascending."""
 
         params = {"order_by": "column_name"}
         result_query = apply_ordering_params(self.query, params, self.response)
 
         order_clause = result_query._order_by_clauses[0]
-        self.assertEqual(str(order_clause), str(asc("column_name")))
+        self.assertEqual(str(asc("column_name")), str(order_clause))
 
     def test_invalid_direction_param(self) -> None:
-        """Test a ValueError is raised for an invalid direction parameter."""
+        """Test a ValueError is raised for an invalid `direction` parameter."""
 
         params = {"order_by": "column_name", "direction": "invalid"}
         with self.assertRaises(ValueError):

--- a/tests/dependencies/test_apply_pagination_params.py
+++ b/tests/dependencies/test_apply_pagination_params.py
@@ -27,31 +27,31 @@ class TestApplyPaginationParams(TestCase):
         self.assertIsInstance(result_query, Select)
 
         # Assert the query contains the correct offset and limit
-        self.assertEqual(result_query._limit, 10)
-        self.assertEqual(result_query._offset, 20)
+        self.assertEqual(10, result_query._limit)
+        self.assertEqual(20, result_query._offset)
 
     def test_missing_params(self) -> None:
         """Test pagination is not applied when parameters are not provided."""
 
         result_query = apply_pagination_params(self.query, {}, self.response)
-        self.assertEqual(result_query._limit, None)
-        self.assertEqual(result_query._offset, None)
+        self.assertEqual(None, result_query._limit)
+        self.assertEqual(None, result_query._offset)
 
     def test_missing_limit_param(self) -> None:
         """Test pagination is not applied when the limit parameters is not provided."""
 
         params = {"offset": 10}
         result_query = apply_pagination_params(self.query, params, self.response)
-        self.assertEqual(result_query._limit, None)
-        self.assertEqual(result_query._offset, None)
+        self.assertEqual(None, result_query._limit)
+        self.assertEqual(None, result_query._offset)
 
     def test_zero_limit_param(self) -> None:
-        """Test setting a limit offset of zero does not apply pagination."""
+        """Test setting an offset of zero does not apply pagination."""
 
         params = {"limit": 0, "offset": 20}
         result_query = apply_pagination_params(self.query, params, self.response)
-        self.assertEqual(result_query._limit, None)
-        self.assertEqual(result_query._offset, None)
+        self.assertEqual(None, result_query._limit)
+        self.assertEqual(None, result_query._offset)
 
     def test_negative_limit_param(self) -> None:
         """Test a ValueError is raised for a negative pagination limit."""
@@ -61,23 +61,23 @@ class TestApplyPaginationParams(TestCase):
             apply_pagination_params(self.query, params, self.response)
 
     def test_missing_offset_param(self) -> None:
-        """Test the offset parameter defaults to zero."""
+        """Test the `offset` parameter defaults to zero."""
 
         params = {"limit": 10}
         result_query = apply_pagination_params(self.query, params, self.response)
-        self.assertEqual(result_query._limit, 10)
-        self.assertEqual(result_query._offset, 0)
+        self.assertEqual(10, result_query._limit)
+        self.assertEqual(0, result_query._offset)
 
     def test_zero_offset_params(self) -> None:
         """Test setting a pagination offset of zero."""
 
         params = {"limit": 10, "offset": 0}
         result_query = apply_pagination_params(self.query, params, self.response)
-        self.assertEqual(result_query._limit, 10)
-        self.assertEqual(result_query._offset, 0)
+        self.assertEqual(10, result_query._limit)
+        self.assertEqual(0, result_query._offset)
 
     def test_negative_offset_param(self) -> None:
-        """Test a ValueError is raised for a negative pagination offset."""
+        """Test a `ValueError` is raised for a negative pagination offset."""
 
         params = {"limit": 10, "offset": -10}
         with self.assertRaises(ValueError):

--- a/tests/dependencies/test_get_ordering_params.py
+++ b/tests/dependencies/test_get_ordering_params.py
@@ -25,40 +25,40 @@ class TestGetOrderingParams(TestCase):
         """Test the default sorting direction when `order_by` is not provided."""
 
         response = self.client.get("/ordering")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
         self.assertEqual(response.json(), {"order_by": None, "direction": "asc"})
 
     def test_valid_ordering_params(self) -> None:
         """Test a valid `order_by` field and sort direction."""
 
         response = self.client.get("/ordering", params={"_order_by_": "name", "_direction_": "desc"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"order_by": "name", "direction": "desc"})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"order_by": "name", "direction": "desc"}, response.json())
 
     def test_case_sensitive_sort_direction(self) -> None:
         """Test case sensitivity for the sort direction input."""
 
         response = self.client.get("/ordering", params={"_order_by_": "created_at", "_direction_": "DESC"})
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(422, response.status_code)
         self.assertIn("Input should be 'asc' or 'desc'", str(response.json()))
 
     def test_invalid_sort_direction(self) -> None:
         """Test an invalid sort direction fails validation."""
 
         response = self.client.get("/ordering", params={"_order_by_": "id", "_direction_": "invalid"})
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(422, response.status_code)
         self.assertIn("Input should be 'asc' or 'desc'", str(response.json()))
 
     def test_only_order_by_provided(self) -> None:
         """Test `order_by` provided without explicitly setting `direction`."""
 
         response = self.client.get("/ordering", params={"_order_by_": "updated_at"})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
         self.assertEqual(response.json(), {"order_by": "updated_at", "direction": "asc"})
 
     def test_empty_order_by_field(self) -> None:
         """Test empty `order_by` field is handled properly."""
 
         response = self.client.get("/ordering", params={"_order_by_": ""})
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
         self.assertEqual(response.json(), {"order_by": "", "direction": "asc"})

--- a/tests/dependencies/test_get_pagination_params.py
+++ b/tests/dependencies/test_get_pagination_params.py
@@ -25,45 +25,45 @@ class TestGetPaginationParams(TestCase):
         """Test default values for pagination parameters."""
 
         response = self.client.get("/pagination")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {'limit': 10, 'offset': 0})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({'limit': 10, 'offset': 0}, response.json())
 
     def test_custom_pagination(self) -> None:
         """Test valid custom pagination values."""
 
         response = self.client.get("/pagination", params={"_limit_": 2, "_offset_": 20})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"limit": 2, "offset": 20})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"limit": 2, "offset": 20}, response.json())
 
     def test_zero_limit(self) -> None:
         """Test a zero limit value passes validation."""
 
         response = self.client.get("/pagination", params={"_limit_": 0, "_offset_": 20})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"limit": 0, "offset": 20})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"limit": 0, "offset": 20}, response.json())
 
     def test_negative_limit(self) -> None:
         """Test negative limit values fail validation."""
 
         response = self.client.get("/pagination", params={"_limit_": -1})
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(422, response.status_code)
 
         error_detail = response.json()['detail'][0]
-        self.assertEqual(error_detail['msg'], "Input should be greater than or equal to 0")
+        self.assertEqual("Input should be greater than or equal to 0", error_detail['msg'])
 
     def test_zero_offset(self) -> None:
         """Test a zero offset value passes validation."""
 
         response = self.client.get("/pagination", params={"_limit_": 10, "_offset_": 0})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"limit": 10, "offset": 0})
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({"limit": 10, "offset": 0}, response.json())
 
     def test_negative_offset(self) -> None:
         """Test negative offset values fail validation."""
 
         response = self.client.get("/pagination", params={"_offset_": -1})
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(422, response.status_code)
 
         error_detail = response.json()['detail'][0]
-        self.assertEqual(error_detail['msg'], "Input should be greater than or equal to 0")
+        self.assertEqual("Input should be greater than or equal to 0", error_detail['msg'])
 

--- a/tests/handlers/test_version_handler.py
+++ b/tests/handlers/test_version_handler.py
@@ -22,5 +22,5 @@ class TestWelcomeHandler(TestCase):
         """Test the version handler returns the correct version number."""
 
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
         self.assertEqual({"version": version}, response.json())

--- a/tests/handlers/test_welcome_handler.py
+++ b/tests/handlers/test_welcome_handler.py
@@ -21,5 +21,5 @@ class TestWelcomeHandler(TestCase):
         """Test the welcome handler returns the correct JSON message."""
 
         response = self.client.get("/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
         self.assertEqual({"message": "Welcome to Auto-Rest!"}, response.json())

--- a/tests/models/test_create_db_metadata.py
+++ b/tests/models/test_create_db_metadata.py
@@ -41,7 +41,7 @@ class TestCreateDbMetadata(TestCase):
 
         metadata = create_db_metadata(sync_engine)
         self.assertIsInstance(metadata, MetaData)
-        self.assertEqual(len(metadata.tables), 2)
+        self.assertEqual(2, len(metadata.tables))
 
     def test_synchronous_metadata_empty_database(self) -> None:
         """Test metadata mapping with a synchronous engine against an empty database."""
@@ -49,7 +49,7 @@ class TestCreateDbMetadata(TestCase):
         sync_engine = create_engine("sqlite:///:memory:")
         metadata = create_db_metadata(sync_engine)
         self.assertIsInstance(metadata, MetaData)
-        self.assertEqual(len(metadata.tables), 0)
+        self.assertEqual(0, len(metadata.tables))
 
     def test_asynchronous_metadata(self) -> None:
         """Test metadata mapping with an asynchronous engine."""
@@ -59,7 +59,7 @@ class TestCreateDbMetadata(TestCase):
 
         metadata = create_db_metadata(async_engine)
         self.assertIsInstance(metadata, MetaData)
-        self.assertEqual(len(metadata.tables), 2)
+        self.assertEqual(2, len(metadata.tables))
 
     def test_asynchronous_metadata_empty_database(self) -> None:
         """Test metadata mapping with an asynchronous engine against an empty database."""
@@ -67,4 +67,4 @@ class TestCreateDbMetadata(TestCase):
         async_engine = create_async_engine("sqlite+aiosqlite:///:memory:")
         metadata = create_db_metadata(async_engine)
         self.assertIsInstance(metadata, MetaData)
-        self.assertEqual(len(metadata.tables), 0)
+        self.assertEqual(0, len(metadata.tables))

--- a/tests/models/test_create_db_url.py
+++ b/tests/models/test_create_db_url.py
@@ -97,7 +97,7 @@ class TestCreateDbUrl(TestCase):
             password=None
         )
         expected_url = f"sqlite:///{path.resolve()}"
-        self.assertEqual(result, expected_url)
+        self.assertEqual(expected_url, result)
 
     def test_create_sqlite_url_with_absolute_path(self) -> None:
         """Test creating a SQLite URL with an absolute file path."""
@@ -111,4 +111,4 @@ class TestCreateDbUrl(TestCase):
             password=None
         )
         expected_url = "sqlite:////absolute/path/to/database.db"
-        self.assertEqual(result, expected_url)
+        self.assertEqual(expected_url, result)


### PR DESCRIPTION
Makes sure everything is documented and formatting consistently. Somewhere along the line I unintentionally deviated from the canonical ordering of arguments in `assertEquals` calls, so I fixed that as well.