### PR TITLE
Keep user credentials out of log messages

### DIFF
--- a/auto_rest/app.py
+++ b/auto_rest/app.py
@@ -53,6 +53,8 @@ def create_app(engine: Engine, models: dict[str, ModelBase], enable_meta: bool =
         A new FastAPI application.
     """
 
+    logging.info('Building API application...')
+
     app = FastAPI(
         title=name.title(),
         version=version,
@@ -65,11 +67,11 @@ def create_app(engine: Engine, models: dict[str, ModelBase], enable_meta: bool =
     app.add_api_route("/version/", version_handler, methods=["GET"], tags=["Application Info"])
 
     if enable_meta:
-        logger.debug(f"Adding meta API route.")
+        logger.debug(f"Adding API route for '/meta/'.")
         app.add_api_route(f"/meta/", create_meta_handler(engine), methods=["GET"], tags=["Application Info"])
 
     for model_name, model_class in models.items():
-        logger.debug(f"Adding API routes for table '{model_name}'.")
+        logger.debug(f"Adding API route for '/db/{model_name}/'.")
         app.add_api_route(f"/db/{model_name}/", create_list_handler(engine, model_class), methods=["GET"], tags=["Database Operations"])
 
     return app

--- a/auto_rest/app.py
+++ b/auto_rest/app.py
@@ -53,7 +53,7 @@ def create_app(engine: Engine, models: dict[str, ModelBase], enable_meta: bool =
         A new FastAPI application.
     """
 
-    logging.info('Building API application...')
+    logging.info('Building API application.')
 
     app = FastAPI(
         title=name.title(),
@@ -87,5 +87,5 @@ def run_app(app: FastAPI, server_host: str, server_port: int, log_level: str) ->
         log_level: The desired server logging level.
     """
 
-    logger.info("Launching API server...")
+    logger.info("Launching API server.")
     uvicorn.run(app, host=server_host, port=server_port, log_level=log_level.lower())

--- a/auto_rest/models.py
+++ b/auto_rest/models.py
@@ -73,7 +73,7 @@ def create_db_engine(url: str, **kwargs) -> Engine | AsyncEngine:
         A SQLAlchemy `Engine` or `AsyncEngine` instance.
     """
 
-    logger.info(f"Establishing database connection...")
+    logger.info(f"Building database engine...")
 
     try:
         engine = create_async_engine(url, **kwargs)

--- a/auto_rest/models.py
+++ b/auto_rest/models.py
@@ -29,7 +29,7 @@ def create_db_url(
     database: str | None = None,
     username: str | None = None,
     password: str | None = None,
-) -> str:
+) -> URL:
     """Create a database URL from the provided parameters.
 
     Args:
@@ -47,7 +47,7 @@ def create_db_url(
     # Handle special case where SQLite uses file paths
     if "sqlite" in driver:
         path = Path(host).resolve()
-        return f"{driver}:///{path}"
+        return URL.create(drivername=driver, database=str(path))
 
     return URL.create(
         drivername=driver,
@@ -56,10 +56,10 @@ def create_db_url(
         host=host,
         port=port,
         database=database,
-    ).render_as_string(hide_password=False)
+    )
 
 
-def create_db_engine(url: str, **kwargs) -> Engine | AsyncEngine:
+def create_db_engine(url: URL, **kwargs) -> Engine | AsyncEngine:
     """Initialize a new database engine.
 
     Instantiates and returns an `Engine` or `AsyncEngine` instance depending
@@ -73,7 +73,7 @@ def create_db_engine(url: str, **kwargs) -> Engine | AsyncEngine:
         A SQLAlchemy `Engine` or `AsyncEngine` instance.
     """
 
-    logger.info(f"Building database engine...")
+    logger.info(f"Building database engine for {url}.")
 
     try:
         engine = create_async_engine(url, **kwargs)
@@ -110,7 +110,7 @@ def create_db_metadata(engine: Engine | AsyncEngine) -> MetaData:
         A MetaData object reflecting the schema of the database.
     """
 
-    logger.info(f"Loading database schema...")
+    logger.info(f"Loading database schema.")
     metadata = MetaData()
 
     try:
@@ -137,7 +137,7 @@ def create_db_models(metadata: MetaData) -> dict[str, ModelBase]:
         A dictionary mapping table names to database models.
     """
 
-    logger.info(f"Building database models...")
+    logger.info(f"Building database models.")
     models = {}
 
     try:
@@ -174,11 +174,13 @@ def create_session_factory(engine: Engine | AsyncEngine, autocommit: bool = Fals
 
     if isinstance(engine, AsyncEngine):
         async_session_factory = async_sessionmaker(bind=engine, autocommit=autocommit, autoflush=autoflush)
+
         async def session_iterator() -> AsyncSession:
             async with async_session_factory() as session:
                 yield session
     else:
         session_factory = sessionmaker(bind=engine, autocommit=autocommit, autoflush=autoflush)
+
         def session_iterator() -> Session:
             with session_factory() as session:
                 yield session

--- a/auto_rest/models.py
+++ b/auto_rest/models.py
@@ -73,7 +73,7 @@ def create_db_engine(url: str, **kwargs) -> Engine | AsyncEngine:
         A SQLAlchemy `Engine` or `AsyncEngine` instance.
     """
 
-    logger.info(f"Connecting to database at {url} ({kwargs}).")
+    logger.info(f"Establishing database connection...")
 
     try:
         engine = create_async_engine(url, **kwargs)
@@ -110,7 +110,7 @@ def create_db_metadata(engine: Engine | AsyncEngine) -> MetaData:
         A MetaData object reflecting the schema of the database.
     """
 
-    logger.info(f"Loading database schema for {engine.url}.")
+    logger.info(f"Loading database schema...")
     metadata = MetaData()
 
     try:
@@ -137,6 +137,7 @@ def create_db_models(metadata: MetaData) -> dict[str, ModelBase]:
         A dictionary mapping table names to database models.
     """
 
+    logger.info(f"Building database models...")
     models = {}
 
     try:
@@ -149,7 +150,7 @@ def create_db_models(metadata: MetaData) -> dict[str, ModelBase]:
                 {"__table__": table},
             )
 
-        logger.info(f"Successfully generated {len(models)} models.")
+        logger.debug(f"Successfully generated {len(models)} models.")
         return models
 
     except Exception as e:  # pragma: no cover

--- a/tests/models/test_create_db_url.py
+++ b/tests/models/test_create_db_url.py
@@ -10,105 +10,65 @@ class TestCreateDbUrl(TestCase):
     def test_create_url_with_all_params(self) -> None:
         """Test creating a database URL with all parameters provided."""
 
-        result = create_db_url(
-            driver="postgresql",
-            host="localhost",
-            port=5432,
-            database="test_db",
-            username="user",
-            password="password"
-        )
+        driver = "postgresql"
+        host = "localhost"
+        port = 5432
+        database = "mydb"
+        username = "user"
+        password = "pass"
 
-        expected_url = "postgresql://user:password@localhost:5432/test_db"
-        self.assertEqual(expected_url, result)
+        result = create_db_url(driver=driver, host=host, port=port, database=database, username=username, password=password)
 
-    def test_create_url_without_password(self) -> None:
-        """Test creating a database URL without a password."""
+        self.assertEqual(driver, result.drivername)
+        self.assertEqual(host, result.host)
+        self.assertEqual(port, result.port)
+        self.assertEqual(database, result.database)
+        self.assertEqual(username, result.username)
+        self.assertEqual(password, result.password)
 
-        result = create_db_url(
-            driver="postgresql",
-            host="localhost",
-            port=5432,
-            database="test_db",
-            username="user",
-            password=None
-        )
+    def test_create_url_without_optional_params(self) -> None:
+        """Test creating a database URL without optional parameters."""
 
-        expected_url = "postgresql://user@localhost:5432/test_db"
-        self.assertEqual(expected_url, result)
+        driver = "mysql"
+        host = "127.0.0.1"
 
-    def test_create_url_without_username_and_password(self) -> None:
-        """Test creating a database URL without a username and password."""
+        result = create_db_url(driver=driver, host=host)
 
-        result = create_db_url(
-            driver="postgresql",
-            host="localhost",
-            port=5432,
-            database="test_db",
-            username=None,
-            password=None
-        )
-
-        expected_url = "postgresql://localhost:5432/test_db"
-        self.assertEqual(expected_url, result)
-
-    def test_create_url_without_port(self) -> None:
-        """Test creating a database URL without a port."""
-
-        result = create_db_url(
-            driver="postgresql",
-            host="localhost",
-            port=None,
-            database="test_db",
-            username="user",
-            password="password"
-        )
-
-        expected_url = "postgresql://user:password@localhost/test_db"
-        self.assertEqual(expected_url, result)
-
-    def test_create_url_without_database(self) -> None:
-        """Test creating a database URL without a database name."""
-
-        result = create_db_url(
-            driver="postgresql",
-            host="localhost",
-            port=5432,
-            database=None,
-            username="user",
-            password="password"
-        )
-
-        expected_url = "postgresql://user:password@localhost:5432"
-        self.assertEqual(expected_url, result)
+        self.assertEqual(driver, result.drivername)
+        self.assertEqual(host, result.host)
+        self.assertIsNone(result.port)
+        self.assertIsNone(result.database)
+        self.assertIsNone(result.username)
+        self.assertIsNone(result.password)
 
     def test_create_sqlite_url_with_relative_path(self) -> None:
         """Test creating a SQLite URL with a relative file path."""
 
+        driver = "sqlite"
         path = Path("path/to/database.db")
         self.assertFalse(path.is_absolute())
 
-        result = create_db_url(
-            driver="sqlite",
-            host=str(path),  # Relative path
-            port=None,
-            database=None,
-            username=None,
-            password=None
-        )
-        expected_url = f"sqlite:///{path.resolve()}"
-        self.assertEqual(expected_url, result)
+        result = create_db_url(driver=driver, host=str(path))
+
+        self.assertEqual(driver, result.drivername)
+        self.assertIsNone(result.host)
+        self.assertIsNone(result.port)
+        self.assertEqual(str(path.resolve()), result.database)
+        self.assertIsNone(result.username)
+        self.assertIsNone(result.password)
 
     def test_create_sqlite_url_with_absolute_path(self) -> None:
         """Test creating a SQLite URL with an absolute file path."""
 
-        result = create_db_url(
-            driver="sqlite",
-            host="/absolute/path/to/database.db",  # Absolute path
-            port=None,
-            database=None,
-            username=None,
-            password=None
-        )
-        expected_url = "sqlite:////absolute/path/to/database.db"
-        self.assertEqual(expected_url, result)
+        driver = "sqlite"
+        path = Path("/absolute/path/to/database.db")
+        self.assertTrue(path.is_absolute())
+
+        result = create_db_url(driver=driver, host=str(path))
+
+        self.assertEqual(driver, result.drivername)
+        self.assertIsNone(result.host)
+        self.assertIsNone(result.port)
+        self.assertEqual(str(path), result.database)
+        self.assertIsNone(result.username)
+        self.assertIsNone(result.password)


### PR DESCRIPTION
The application was handling database URLs as strings, which don't sanitize when formatted into log messages. This PR switches to URL objects, which have sanitation built in.