### PR TITLE
Drops handler type hints

### DIFF
--- a/auto_rest/handlers.py
+++ b/auto_rest/handlers.py
@@ -22,13 +22,13 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-async def welcome_handler() -> dict[str, int | str]:
+async def welcome_handler():
     """Return a welcome message in JSON format pointing users to the docs."""
 
     return {"message": "Welcome to Auto-Rest!"}
 
 
-async def version_handler() -> dict[str, int | str]:
+async def version_handler():
     """Return the application version number in JSON format."""
 
     return {"version": version}
@@ -73,7 +73,7 @@ def create_list_handler(engine: Engine, model: ModelBase) -> callable:
         session: Session | AsyncSession = Depends(create_session_factory(engine)),
         pagination_params: dict[str, int] = Depends(get_pagination_params),
         ordering_params: dict[str, int] = Depends(get_ordering_params),
-    ) -> dict[str, int | str]:
+    ):
         query = select(model)
         query = apply_pagination_params(query, pagination_params, response)
         query = apply_ordering_params(query, ordering_params, response)


### PR DESCRIPTION
Fast api uses the types to format returned values and the current types are breaking the list endpoints.