### PR TITLE
Reduces log outputs during tests

### DIFF
--- a/tests/app/test_create_app.py
+++ b/tests/app/test_create_app.py
@@ -32,7 +32,7 @@ class TestCreateApp(TestCase):
     def setUpClass(cls) -> None:
         """Set up a temporary SQLite database."""
 
-        cls.engine = create_engine(f"sqlite:///:memory:", echo=True)
+        cls.engine = create_engine("sqlite:///:memory:")
         Base.metadata.create_all(bind=cls.engine)
 
         cls.mock_models = {

--- a/tests/models/test_create_db_interface.py
+++ b/tests/models/test_create_db_interface.py
@@ -44,10 +44,10 @@ class TestCreateDbInterface(unittest.TestCase):
     def test_field_defaults(self) -> None:
         """Test interface fields have the correct default values."""
 
-        self.assertIsNone(self.interface.__fields__["id"].default)
-        self.assertIsNone(self.interface.__fields__["title"].default)
-        self.assertEqual(self.interface.__fields__["rating"].default.arg, 5)
+        self.assertIsNone(self.interface.model_fields["id"].default)
+        self.assertIsNone(self.interface.model_fields["title"].default)
+        self.assertEqual(self.interface.model_fields["rating"].default.arg, 5)
 
-        default_created_at = self.interface.__fields__["created_at"].default.arg
+        default_created_at = self.interface.model_fields["created_at"].default.arg
         self.assertTrue(callable(default_created_at))
         self.assertEqual(date.today(), default_created_at(None))

--- a/tests/models/test_create_db_metadata.py
+++ b/tests/models/test_create_db_metadata.py
@@ -1,7 +1,7 @@
 import asyncio
 from unittest import TestCase
 
-from sqlalchemy import Column, create_engine, Engine, INTEGER, MetaData, Table, VARCHAR
+from sqlalchemy import Column, create_engine, Engine, INTEGER, MetaData, Table
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from auto_rest.models import create_db_metadata
@@ -43,6 +43,8 @@ class TestCreateDbMetadata(TestCase):
         self.assertIsInstance(metadata, MetaData)
         self.assertEqual(2, len(metadata.tables))
 
+        engine.dispose()
+
     def test_synchronous_metadata_empty_database(self) -> None:
         """Test metadata mapping with a synchronous engine against an empty database."""
 
@@ -51,6 +53,8 @@ class TestCreateDbMetadata(TestCase):
         metadata = create_db_metadata(engine)
         self.assertIsInstance(metadata, MetaData)
         self.assertEqual(0, len(metadata.tables))
+
+        engine.dispose()
 
     def test_asynchronous_metadata(self) -> None:
         """Test metadata mapping with an asynchronous engine."""
@@ -62,6 +66,8 @@ class TestCreateDbMetadata(TestCase):
         self.assertIsInstance(metadata, MetaData)
         self.assertEqual(2, len(metadata.tables))
 
+        asyncio.run(async_engine.dispose())
+
     def test_asynchronous_metadata_empty_database(self) -> None:
         """Test metadata mapping with an asynchronous engine against an empty database."""
 
@@ -70,3 +76,5 @@ class TestCreateDbMetadata(TestCase):
         metadata = create_db_metadata(async_engine)
         self.assertIsInstance(metadata, MetaData)
         self.assertEqual(0, len(metadata.tables))
+
+        asyncio.run(async_engine.dispose())


### PR DESCRIPTION
A few changes to eliminate various warnings/logs echoed to the console when running the test suite:

1. Disables `echo` for test engines.
 2. Switch from deprecated `__fields__` attribute to `model_fields` 
 3. Ensures engine objects are disposed of after use