### PR TITLE
Adds support for fields without defaults in dynamic interfaces

### DIFF
--- a/auto_rest/models.py
+++ b/auto_rest/models.py
@@ -5,10 +5,8 @@ import logging
 from pathlib import Path
 from typing import Callable
 
-import pydantic
-from pydantic.main import ModelT
+from pydantic.main import create_model, ModelT
 from sqlalchemy import create_engine, Engine, MetaData, URL
-from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import declarative_base, Session
 
@@ -85,24 +83,15 @@ def create_db_engine(url: URL, **kwargs) -> DBEngine:
 
     logger.info(f"Building database engine for {url}.")
 
-    # Attempt to create an async engine by default.
-    try:
+    if url.get_dialect().is_async:
         engine = create_async_engine(url, **kwargs)
         logger.debug("Asynchronous connection established.")
         return engine
 
-    except InvalidRequestError as e:
-        logger.warning(f"Async connection failed, falling back to sync. Error: {e}")
-
-    # Fall back to a synchronous engine if async fails.
-    try:
+    else:
         engine = create_engine(url, **kwargs)
         logger.debug("Synchronous connection established.")
         return engine
-
-    except Exception as e:  # pragma: no cover
-        logger.error(f"Could not connect to the database: {e}")
-        raise
 
 
 async def _async_reflect_metadata(engine: AsyncEngine, metadata: MetaData) -> None:
@@ -180,9 +169,12 @@ def create_db_interface(model: DBModel) -> type[ModelT]:
         A Pydantic model class with the same structure as the provided SQLAlchemy model.
     """
 
-    # Dynamic Pydantic models require a map of column names to their type and default value.
-    columns = {col.name: (col.type.python_type, col.default) for col in model.__table__.columns}
-    return pydantic.create_model(model.__name__, **columns)
+    fields = {
+        col.name: (col.type.python_type, col.default if col.default is not None else ...)
+        for col in model.__table__.columns
+    }
+
+    return create_model(model.__name__, **fields)
 
 
 def create_session_iterator(engine: DBEngine) -> Callable[[], DBSession]:

--- a/tests/models/test_create_db_interface.py
+++ b/tests/models/test_create_db_interface.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import date
 
 import pydantic
+from pydantic_core import PydanticUndefined
 from sqlalchemy import Column, Date, Float, Integer, String
 
 from auto_rest.models import create_db_interface, DBModel
@@ -44,10 +45,14 @@ class TestCreateDbInterface(unittest.TestCase):
     def test_field_defaults(self) -> None:
         """Test interface fields have the correct default values."""
 
-        self.assertIsNone(self.interface.model_fields["id"].default)
-        self.assertIsNone(self.interface.model_fields["title"].default)
+        # Verify fields without default values
+        self.assertEqual(PydanticUndefined, self.interface.model_fields["id"].default)
+        self.assertEqual(PydanticUndefined, self.interface.model_fields["title"].default)
+
+        # Verify fields with fixed default values
         self.assertEqual(self.interface.model_fields["rating"].default.arg, 5)
 
+        # Verify fields with dynamic default values
         default_created_at = self.interface.model_fields["created_at"].default.arg
         self.assertTrue(callable(default_created_at))
         self.assertEqual(date.today(), default_created_at(None))


### PR DESCRIPTION
Fixes a bug where database fields with no default value were represented in Pydantic models as having a default value of `None`. Keeping with standard Pydantic design principles, f ields without defaults now have `PydanticUndefined` as their default