### PR TITLE
Allows users to set OpenAPI schema title and version from the CLI

### DIFF
--- a/auto_rest/cli.py
+++ b/auto_rest/cli.py
@@ -5,6 +5,8 @@ from argparse import ArgumentParser
 
 __all__ = ["create_argument_parser"]
 
+VERSION = importlib.metadata.version(__package__)
+
 
 def create_argument_parser(exit_on_error: bool = True) -> ArgumentParser:
     """Create a command-line argument parser with predefined options / arguments.
@@ -22,7 +24,7 @@ def create_argument_parser(exit_on_error: bool = True) -> ArgumentParser:
         exit_on_error=exit_on_error
     )
 
-    parser.add_argument("--version", action="version", version=importlib.metadata.version(__package__))
+    parser.add_argument("--version", action="version", version=VERSION)
     parser.add_argument(
         "--log-level",
         default="INFO",
@@ -59,5 +61,9 @@ def create_argument_parser(exit_on_error: bool = True) -> ArgumentParser:
     server = parser.add_argument_group(title="server settings")
     server.add_argument("--server-host", default="127.0.0.1", help="API server host address.")
     server.add_argument("--server-port", type=int, default=8081, help="API server port number.")
+
+    schema = parser.add_argument_group(title="api schema")
+    schema.add_argument("--schema-title", default="Auto-REST", help="title for the generated OpenAPI schema.")
+    schema.add_argument("--schema-version", default=VERSION, help="version number for the generated OpenAPI schema.")
 
     return parser

--- a/tests/app/test_create_app.py
+++ b/tests/app/test_create_app.py
@@ -43,11 +43,6 @@ class TestCreateApp(TestCase):
         cls.app: FastAPI = create_app(cls.engine, cls.mock_models)
         cls.client = TestClient(cls.app)
 
-    def test_app_title(self) -> None:
-        """Test the application's title."""
-
-        self.assertEqual("Auto-REST", self.app.title)
-
     def test_has_root_endpoint(self) -> None:
         """Test the application has a root endpoint."""
 

--- a/tests/app/test_create_router.py
+++ b/tests/app/test_create_router.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from sqlalchemy import Column, Integer, String
 
-from auto_rest.app import create_router
+from auto_rest.app import create_route_handlers
 from auto_rest.models import DBModel
 
 
@@ -38,7 +38,7 @@ class TestCreateRouter(unittest.TestCase):
     def test_router_single_primary_key(self) -> None:
         """Test router create for a table with a single primary key."""
 
-        router = create_router(self.mock_engine, SinglePKModel)
+        router = create_route_handlers(self.mock_engine, SinglePKModel)
         actual_routes = [(route.path, method) for route in router.routes for method in route.methods]
         expected_routes = [
             ("/", "GET"),
@@ -54,7 +54,7 @@ class TestCreateRouter(unittest.TestCase):
     def test_router_multiple_primary_keys(self) -> None:
         """Test router create for a table with a multiple primary keys."""
 
-        router = create_router(self.mock_engine, MultiplePKModel)
+        router = create_route_handlers(self.mock_engine, MultiplePKModel)
         actual_routes = [(route.path, method) for route in router.routes for method in route.methods]
         expected_routes = [
             ("/", "GET"),


### PR DESCRIPTION
Adds CLI arguments for the OpenAPI schema title and version number. This way administrators can customize the result and keep their own user's from getting confused.