### PR TITLE
Renames cli functions

### DIFF
--- a/auto_rest/__main__.py
+++ b/auto_rest/__main__.py
@@ -15,10 +15,10 @@ def main() -> None:
     """Parse command-line arguments and launch an API server."""
 
     try:
-        parser = create_argument_parser()
+        parser = create_cli_parser()
         args = vars(parser.parse_args())
 
-        configure_console_logging(args.pop('log_level'))
+        configure_cli_logging(args.pop('log_level'))
         run_application(**args)
 
     except KeyboardInterrupt:

--- a/auto_rest/cli.py
+++ b/auto_rest/cli.py
@@ -36,12 +36,12 @@ from argparse import ArgumentParser, HelpFormatter
 
 from uvicorn.logging import DefaultFormatter
 
-__all__ = ['VERSION', "create_argument_parser", "configure_console_logging"]
+__all__ = ['VERSION', "create_cli_parser", "configure_cli_logging"]
 
 VERSION = importlib.metadata.version(__package__)
 
 
-def create_argument_parser(exit_on_error: bool = True) -> ArgumentParser:
+def create_cli_parser(exit_on_error: bool = True) -> ArgumentParser:
     """Create a command-line argument parser with preconfigured arguments.
 
     Args:
@@ -105,7 +105,7 @@ def create_argument_parser(exit_on_error: bool = True) -> ArgumentParser:
     return parser
 
 
-def configure_console_logging(level: str) -> None:
+def configure_cli_logging(level: str) -> None:
     """Enable console logging with the specified application log level.
 
     Calling this method overrides and removes all previously configured

--- a/tests/cli/test_configure_cli_logging.py
+++ b/tests/cli/test_configure_cli_logging.py
@@ -1,17 +1,17 @@
 import logging
 from unittest import TestCase
 
-from auto_rest.cli import configure_console_logging
+from auto_rest.cli import configure_cli_logging
 
 
-class TestConfigureCOnsoleLogging(TestCase):
-    """Unit tests for the `configure_logging` function."""
+class TestConfigureCliLogging(TestCase):
+    """Unit tests for the `configure_cli_logging` function."""
 
     def test_log_level_is_set(self) -> None:
         """Test the logging level is configured."""
 
         for log_level_str in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-            configure_console_logging(log_level_str)
+            configure_cli_logging(log_level_str)
 
             # The `getLevelName` method returns the numeric logging level when
             # passed the level name string. This was originally a bug, but is
@@ -22,7 +22,7 @@ class TestConfigureCOnsoleLogging(TestCase):
     def test_log_format_is_set(self) -> None:
         """Test the logging format is configured."""
 
-        configure_console_logging("INFO")
+        configure_cli_logging("INFO")
         handler = logging.getLogger().handlers[0]
 
         self.assertIsInstance(handler, logging.StreamHandler)
@@ -32,4 +32,4 @@ class TestConfigureCOnsoleLogging(TestCase):
         """Test an invalid logging level raises an error."""
 
         with self.assertRaisesRegex(ValueError, "Invalid logging level"):
-            configure_console_logging("INVALID")
+            configure_cli_logging("INVALID")

--- a/tests/cli/test_create_cli_parser.py
+++ b/tests/cli/test_create_cli_parser.py
@@ -1,11 +1,11 @@
 from argparse import ArgumentError
 from unittest import TestCase
 
-from auto_rest.cli import create_argument_parser, VERSION
+from auto_rest.cli import create_cli_parser, VERSION
 
 
-class TestCreateArgumentParser(TestCase):
-    """Unit tests for the `create_argument_parser` function.
+class TestCreateCliParser(TestCase):
+    """Unit tests for the `create_cli_parser` function.
 
     Individual methods target behavior for a different subset of commandline arguments.
     """
@@ -13,7 +13,7 @@ class TestCreateArgumentParser(TestCase):
     def setUp(self) -> None:
         """Set up a new parser instance for each test."""
 
-        self.parser = create_argument_parser(exit_on_error=False)
+        self.parser = create_cli_parser(exit_on_error=False)
 
     def test_parser_name(self) -> None:
         """Verify the parser is created with the correct program name."""


### PR DESCRIPTION
Renames functions in the CLI module for clarity and consistency with other function names.