### PR TITLE
Raise a validation error when ordering by invalid column names

### DIFF
--- a/auto_rest/params.py
+++ b/auto_rest/params.py
@@ -35,6 +35,7 @@ the arguments onto a SQLAlchemy query.
 from typing import Literal
 
 from fastapi import Query
+from fastapi.exceptions import RequestValidationError
 from sqlalchemy import asc, desc
 from sqlalchemy.sql.selectable import Select
 from starlette.responses import Response
@@ -132,17 +133,28 @@ def apply_ordering_params(query: Select, params: dict, response: Response) -> Se
     order_by = params.get("order_by")
     direction = params.get("direction")
 
-    # Set response headers
+    # Set common response headers
     response.headers["X-Order-By"] = str(order_by)
     response.headers["X-Order-Direction"] = str(direction)
-    response.headers["X-Order-Applied"] = "true"
 
-    # Do not apply ordering for invalid column names and fail gracefully
-    if order_by not in query.columns.keys():
+    if order_by is None:
         response.headers["X-Order-Applied"] = "false"
         return query
 
+    # Provide a clear error message when dealing with invalid column names
+    columns = tuple(query.columns.keys())
+    if order_by not in columns:
+        raise RequestValidationError(
+            errors=[{
+                "loc": ("query", "order_by"),
+                "msg": f"Input should be one of {columns}.",
+                "type": "value_error",
+                "input": order_by,
+            }]
+        )
+
     # Default to ascending order for an invalid ordering direction
+    response.headers["X-Order-Applied"] = "true"
     if direction == "desc":
         return query.order_by(desc(order_by))
 

--- a/tests/params/test_apply_ordering_params.py
+++ b/tests/params/test_apply_ordering_params.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from fastapi import Response
+from fastapi.exceptions import RequestValidationError
 from sqlalchemy import Column, Integer, MetaData, Table
 from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import asc, desc, Select
@@ -83,11 +84,8 @@ class TestApplyOrderingParams(TestCase):
         self.assertEqual("None", self.response.headers.get("X-Order-Direction"))
 
     def test_invalid_column_name(self) -> None:
-        """Verify ordering is not applied for an invalid column name"""
+        """Verify a validation error is raised for an invalid column name."""
 
         params = {"order_by": "bad_name"}
-        result_query = apply_ordering_params(self.query, params, self.response)
-        self.assertFalse(result_query._order_by_clauses)
-
-        self.assertEqual("false", self.response.headers.get("X-Order-Applied"))
-        self.assertEqual("bad_name", self.response.headers.get("X-Order-By"))
+        with self.assertRaises(RequestValidationError):
+            apply_ordering_params(self.query, params, self.response)


### PR DESCRIPTION
Don't love this implementation as it adds validation in the "apply" method when the rest of the validation is handled implicitly by the corresponding "get" method. I'd much rather have all the validation in one place. However, I don't see an obvious way to add the validation cleanly to the get method. Submitting this PR since progress is better than perfection.