### PR TITLE
Fixes bug where query filters default to None

### DIFF
--- a/auto_rest/handlers.py
+++ b/auto_rest/handlers.py
@@ -208,8 +208,8 @@ def create_list_records_handler(engine: DBEngine, table: Table) -> Callable[...,
         query = select(table)
 
         # Fetch data per the request parameters
-        for param, value in filters.model_dump():
-            if param in col_names:
+        for param, value in filters:
+            if value is not None:
                 column = getattr(table.c, param)
                 if value.lower() == "_null_":
                     query = query.filter(column.is_(None))


### PR DESCRIPTION
Filter query parameters were defaulting to `None` resulting in no data being returned.