### PR TITLE
Fix version extraction from release tag in workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -15,8 +15,16 @@ jobs:
       - name: Determine version from release tag
         id: get_version
         run: |
-          release_tag=${{github.ref}}
-          version="${release_tag#refs/tags/v}"
+          release_tag="${{ github.event.release.tag_name }}"
+          version="${release_tag#v}"
+
+          echo "Release tag: $release_tag"
+          echo "Derived release version: version"
+          if [[ -z "$version" ]]; then
+            echo "::error::Derived version is empty."
+            exit 1
+          fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
   build:
@@ -24,7 +32,7 @@ jobs:
     needs: version
     uses: ./.github/workflows/Build.yml
     with:
-      version: ${{needs.version.outputs.version}}
+      version: ${{ needs.version.outputs.version }}
 
   test:
     name: Test
@@ -43,4 +51,4 @@ jobs:
       packages: write
       pages: write
     with:
-      version: ${{needs.version.outputs.version}}
+      version: ${{ needs.version.outputs.version }}


### PR DESCRIPTION
Updates to the publish CI workflow to use the more stable `github.event.release.tag_name` context over the recently buggy `github.ref` context.